### PR TITLE
Add paket.lock to simplify build and fix dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ Test/obj/
 Test/bin/
 .paket/paket.exe
 packages
-paket.lock
 Test/Script.fsx
 Test/Script.fsx
 *.js

--- a/paket.lock
+++ b/paket.lock
@@ -1,0 +1,4 @@
+NUGET
+  remote: https://nuget.org/api/v2
+  specs:
+    FAKE (3.26.1)


### PR DESCRIPTION
As far as I know, Paket projects generally include `paket.lock` in the repositories to fix the versions of dependencies (though there are not many here yet). It also means that you can just run `build` from the command line and it will work (provided that we fix #4).