### PR TITLE
Resolve correct directory for .fsproj file. "\" doesn't work on OS X.

### DIFF
--- a/src/core.fs
+++ b/src/core.fs
@@ -391,7 +391,7 @@ type Core() =
             let projExist = arr |> Array.tryFind(fun a -> a.Split('.').[1] = "fsproj")
             match projExist with
             | Some a -> 
-                let path = p + "\\" + a
+                let path = Globals.atom.project.resolve a
                 service |> AutocompleteHandler.project path (fun _ -> service |> AutocompleteHandler.parseCurrent (fun _ -> ()) |> ignore)
                 |> ignore
             | None -> service |> AutocompleteHandler.parseCurrent (fun _ -> ()) |> ignore


### PR DESCRIPTION
There is probably a better way to do this as it looks like Globals.atom.project.resolve may be deprecated in the Atom API.